### PR TITLE
Discard burn-in samples

### DIFF
--- a/R/harmonicHMC.R
+++ b/R/harmonicHMC.R
@@ -59,7 +59,7 @@ harmonicHMC <- function(n,
   if (sum(F %*% init + g > 0) < length(g)) {
     stop("Initial value x does not satisfy Fx + g >=0")
   }
-  samples <- matrix(nrow = n + burnin, ncol = ncol(F))
+  samples <- matrix(nrow = n, ncol = ncol(F))
   randomBounceTime <-
     ifelse(length(time) == 2, TRUE, FALSE)
   bounceDistances <- vector(mode = "list",
@@ -87,10 +87,12 @@ harmonicHMC <- function(n,
       diagnosticMode
     )
     position <- results$position
-    samples[i,] <- unwhitenPosition(position,
-                                    choleskyFactor,
-                                    mean,
-                                    precFlg)
+    if (i > burnin) {
+      samples[i - burnin, ] <- unwhitenPosition(position,
+                                                choleskyFactor,
+                                                mean,
+                                                precFlg)
+    }
     if (diagnosticMode) {
       bounceDistances[[i]] <- results$bounceDistances
     }

--- a/R/zigzagHMC.R
+++ b/R/zigzagHMC.R
@@ -77,7 +77,7 @@ zigzagHMC <- function(n,
     }
   }
   
-  samples <- array(0, c(n + burnin, ndim))
+  samples <- array(0, c(n, ndim))
   
   if (nutsFlg) {
     if (!is.null(step)) {
@@ -129,7 +129,9 @@ zigzagHMC <- function(n,
       engine = engine,
       stepZZHMC = t
     )
-    samples[i, ] <- position
+    if (i > burnin) {
+      samples[i - burnin, ] <- position
+    }
   }
   return(samples)
 }


### PR DESCRIPTION
`zigzagHMC()` and `harmonicHMC()` as previously implemented return burn-in samples. I believe it to be a bug/bad feature b/c it makes the `burnin` parameter useless, so went ahead and fixed it. But I am requesting a quick review in case there was some reason you designed the functions that way. 