### PR TITLE
Remove default option to set seed

### DIFF
--- a/R/harmonicHMC.R
+++ b/R/harmonicHMC.R
@@ -50,7 +50,7 @@ harmonicHMC <- function(nSample,
                         init,
                         time = c(pi / 8, pi / 2),
                         precFlg,
-                        seed = 1,
+                        seed = NULL,
                         extraOutputs = c()) {
   if (length(time) == 1) {
     time[2] <- time[1]
@@ -79,7 +79,9 @@ harmonicHMC <- function(nSample,
                              choleskyFactor,
                              mean,
                              precFlg)
-  set.seed(seed)
+  if(!is.null(seed)){
+    set.seed(seed)
+  }
   for (i in 1:(nSample + burnin)) {
     momentum <- rnorm(ncol(F))
     results <- simulateWhitenedDynamics(


### PR DESCRIPTION
Setting seed within a function may affect global seeding. For example, when simulating multiple datasets in the main program, using the "harmonicHMC" with a specified seed can change the seed and influence datasets created later.
So a specific seed should only be set here if the user specifies this option.